### PR TITLE
Us124t163

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,15 @@
         android:theme="@style/Theme.Poste"
         tools:targetApi="31">
         <activity
+            android:name=".activities.NewPostActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activities.EditFolderActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/example/poste/activities/DashboardActivity.java
+++ b/app/src/main/java/com/example/poste/activities/DashboardActivity.java
@@ -32,9 +32,6 @@ import com.example.poste.http.RetrofitClient;
 import com.example.poste.models.User;
 import com.example.poste.utils.utils;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -196,7 +193,8 @@ public class DashboardActivity extends PActivity {
                         return true;
                     case R.id.menu_post:
                         // Handle post creation
-                        showCreatePostDialog();
+                        Intent intent = new Intent(DashboardActivity.this, NewPostActivity.class);
+                        startActivity(intent);
                         return true;
                     default:
                         return false;

--- a/app/src/main/java/com/example/poste/activities/DashboardActivity.java
+++ b/app/src/main/java/com/example/poste/activities/DashboardActivity.java
@@ -27,7 +27,7 @@ import com.example.poste.callbacks.UpdateCallback;
 import com.example.poste.models.Folder;
 import com.example.poste.http.FolderRequest;
 import com.example.poste.http.MyApiService;
-import com.example.poste.http.PostRequest;
+import com.example.poste.http.CreatePostRequest;
 import com.example.poste.http.RetrofitClient;
 import com.example.poste.models.User;
 import com.example.poste.utils.utils;
@@ -206,112 +206,7 @@ public class DashboardActivity extends PActivity {
         popupMenu.show();
     }
 
-
-    private void showCreatePostDialog() {
-        // Inflate the layout for the dialog
-        LayoutInflater inflater = LayoutInflater.from(this);
-        View dialogView = inflater.inflate(R.layout.layout_dialog_create_post, null);
-
-        // Find the RadioGroup and EditText fields in the dialog
-        EditText editTextItemName = dialogView.findViewById(R.id.editTextItemName);
-        EditText editTextItemLink = dialogView.findViewById(R.id.editTextItemLink);
-        Spinner spinnerNewPostFolder = dialogView.findViewById(R.id.spinnerNewPostFolder);
-
-        // Setup for the dropdown menu
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(
-                this,
-                android.R.layout.simple_spinner_item,
-                new ArrayList<>(folderNameToIdMap.keySet())
-        );
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spinnerNewPostFolder.setAdapter(adapter);
-
-        // Create the AlertDialog
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setView(dialogView);
-        builder.setTitle("Create Post");
-
-        // Set the positive button (Create button) click listener
-        builder.setPositiveButton("Create", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                // Get the item name and link from the EditText fields
-                String itemName = editTextItemName.getText().toString().trim();
-                String itemLink = editTextItemLink.getText().toString().trim();
-                String selectedFolderName = spinnerNewPostFolder.getSelectedItem().toString();
-                String selectedFolderId = folderNameToIdMap.get(selectedFolderName);
-
-                if (itemName == "" || itemLink == null || itemLink == "") {
-                    Toast.makeText(
-                            DashboardActivity.this,
-                            "Cannot create post, please enter name and link",
-                            Toast.LENGTH_LONG
-                    ).show();
-                    return;
-                }
-
-                if (!itemLink.matches("^((http|https):\\/\\/)(www.)?[a-zA-Z0-9@:%._\\\\+~#?&/=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\\\+~#?&/=]*)$")) {
-                    Toast.makeText(
-                            DashboardActivity.this,
-                            "Invalid Link",
-                            Toast.LENGTH_LONG
-                    ).show();
-                    return;
-                }
-
-                // Handle post creation logic
-                Call<ResponseBody> call = apiService.createPost(
-                        currentUser.getTokenHeaderString(),
-                        new PostRequest(itemName, "", itemLink, selectedFolderId)
-                );
-
-                call.enqueue(new Callback<ResponseBody>() {
-                    @Override
-                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-                        if (response.isSuccessful()) {
-                            // Display success message, then reload Dashboard
-                            // For simplicity, let's just display a toast message with the post details
-                            Toast.makeText(
-                                    DashboardActivity.this,
-                                    "Post created:\nName: " + itemName + "\nLink: " + itemLink,
-                                    Toast.LENGTH_LONG
-                            ).show();
-                            dialog.dismiss();
-                            Intent intent = new Intent(DashboardActivity.this, DashboardActivity.class);
-                            intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                            startActivity(intent);
-                            finish();
-                        } else {
-                            Toast.makeText(
-                                    DashboardActivity.this,
-                                    "Post creation failed.",
-                                    Toast.LENGTH_LONG
-                            ).show();
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(Call<ResponseBody> call, Throwable t) {
-                        Toast.makeText(DashboardActivity.this, "Post creation failed.", Toast.LENGTH_LONG).show();
-                    }
-                });
-            }
-        });
-
-        // Set the negative button (Cancel button) click listener
-        builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                // Dismiss the dialog (do nothing)
-                dialog.dismiss();
-            }
-        });
-
-        // Show the AlertDialog
-        AlertDialog dialog = builder.create();
-        dialog.show();
-    }
-
+    // Removed Create Post dialog in favor of NewPostActivity
 
     private void showCreateFolderDialog() {
         // Inflate the layout for the dialog

--- a/app/src/main/java/com/example/poste/activities/FolderViewActivity.java
+++ b/app/src/main/java/com/example/poste/activities/FolderViewActivity.java
@@ -65,7 +65,8 @@ public class FolderViewActivity extends AppCompatActivity {
         // Create listeners for the folder buttons
         newBut.setOnClickListener(view -> {
             PosteApplication.setSelectedPost(null);
-            Intent intent = new Intent(FolderViewActivity.this, EditPostActivity.class);
+            Intent intent = new Intent(FolderViewActivity.this, NewPostActivity.class);
+            intent.putExtra("default", PosteApplication.getSelectedFolder().getTitle());
             startActivity(intent);
         });
 

--- a/app/src/main/java/com/example/poste/activities/LoginActivity.java
+++ b/app/src/main/java/com/example/poste/activities/LoginActivity.java
@@ -52,7 +52,8 @@ public class LoginActivity extends AppCompatActivity {
         passwordField = findViewById(R.id.editTextTextPassword);
 
         buttonLoginSubmit = findViewById(R.id.loginLoginbtn);
-
+        Boolean isReturn = getIntent().getBooleanExtra("return", false); // if true, dont start dashboard activity, just finish this one
+        Log.d("debug", "isReturn: " + isReturn);
 
         // adds a hyperlink to redirect user to the login page
         SpannableString spannable = new SpannableString(hyperlinkTextView.getText());
@@ -108,10 +109,17 @@ public class LoginActivity extends AppCompatActivity {
                         } catch (JSONException err){
                             Log.e("Json Error", err.toString());
                         }
-                        // open dashboard activity
-                        Intent dashboardIntent = new Intent(LoginActivity.this, DashboardActivity.class);
-                        finish();
-                        startActivity(dashboardIntent);
+                        if (isReturn){
+                            Log.d("debug", "isReturn is true");
+                            Log.d("debug", "Finishing activity, returning to previous activity");
+                            finish();
+                        } else {
+                            Log.d("debug", "isReturn is false");
+                            Log.d("debug", "Starting dashboard activity");
+                            Intent intent = new Intent(LoginActivity.this, DashboardActivity.class);
+                            finish();
+                            startActivity(intent);
+                        }
                     }else {
                         Toast.makeText(LoginActivity.this, "Incorrect credentials.", Toast.LENGTH_SHORT).show();
                     }

--- a/app/src/main/java/com/example/poste/activities/NewPostActivity.java
+++ b/app/src/main/java/com/example/poste/activities/NewPostActivity.java
@@ -1,61 +1,185 @@
 package com.example.poste.activities;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
+import android.util.Log;
 import android.widget.Spinner;
 import android.widget.Toast;
-import android.util.Log;
 
 
 import com.example.poste.R;
 import com.example.poste.callbacks.UpdateCallback;
+import com.example.poste.http.CreatePostRequest;
+import com.example.poste.http.LoginRequest;
+import com.example.poste.http.MyApiService;
+import com.example.poste.http.RetrofitClient;
 import com.example.poste.models.Folder;
 import com.example.poste.models.User;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.sql.Array;
+import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class NewPostActivity extends AppCompatActivity {
 
-    private String title;
+    private Intent newPostIntent;
 
-    private String link;
+    private Button buttonSaveChanges;
 
-    private String description;
+    private Button buttonCancelChanges;
 
-    private String tags;
+    private Spinner chooseFolderSpinner;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_new_post);
-        if (User.getUser().getToken() == null || User.getUser().getToken().isEmpty()) {
+        newPostIntent = getIntent();
+        buttonSaveChanges = findViewById(R.id.buttonSaveChanges);
+        buttonCancelChanges = findViewById(R.id.buttonCancelChanges);
+        chooseFolderSpinner = findViewById(R.id.chooseFolderSpinner);
+
+        buttonCancelChanges.setOnClickListener(v -> {
+            Log.d("NewPostActivity", "Cancel changes clicked");
+            finish();
+        });
+
+        if (!User.getUser().isLoggedIn()) {
             // user needs to login
             Log.d("NewPostActivity", "User needs to login");
             Intent loginIntent = new Intent(this, LoginActivity.class);
             loginIntent.putExtra("return", true);
             startActivity(loginIntent);
+            // when the user logs in, LoginActivity returns and onResume will be called
         } else {
             Log.d("NewPostActivity", "User is logged in");
             Log.d("NewPostActivity", "User token: " + User.getUser().getToken());
+            handleNewPost();
         }
-        handleSharedContent(getIntent());
+    }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Log.d("NewPostActivity", "onResume called; returning from LoginActivity?");
+        UpdateCallback callback = new UpdateCallback() {
+
+            @Override
+            public void onSuccess() {
+                Log.d("NewPostActivity", "Retrieved user data");
+                handleNewPost();
+            }
+
+            @Override
+            public void onError(String errorMessage) {
+                Log.d("NewPostActivity", "Error retrieving user data: " + errorMessage);
+                handleNewPost();
+            }
+        };
+        User.getUser().updateFoldersAndPosts(callback);
     }
 
 
-    private void handleSharedContent(Intent intent) {
-        String sharedText = intent.getStringExtra(Intent.EXTRA_TEXT);
+    private void handleNewPost() {
+        String sharedText = null;
+        if (newPostIntent != null
+                && newPostIntent.getAction() != null
+                && newPostIntent.getAction().equals(Intent.ACTION_SEND)
+                && newPostIntent.getType() != null
+                && newPostIntent.getType().equals("text/plain")
+                && newPostIntent.getStringExtra(Intent.EXTRA_TEXT) != null
+        ) {
+            sharedText = newPostIntent.getStringExtra(Intent.EXTRA_TEXT);
+        } else {
+            Log.d("NewPostActivity", "No intent to pre-fill post");
+        }
+
         if (sharedText != null) {
             EditText linkEditText = findViewById(R.id.editTextPostLink);
             linkEditText.setText(sharedText);
+        } else {
+            Log.d("NewPostActivity", "No shared text");
         }
+
+        List<Folder> folders = new ArrayList<>();
+        folders.add(new Folder.Builder()
+                .setTitle("-- Select a Folder --")
+                .setId("0")
+                .build());
+        // setup folder spinner
+        folders.addAll(User.getUser().getFolders());
+        ArrayAdapter<Folder> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, folders);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        chooseFolderSpinner.setAdapter(adapter);
+        // set default folder, if applicable
+        String defaultFolder = newPostIntent.getStringExtra("default");
+        if (defaultFolder != null) {
+            for (int i = 0; i < folders.size(); i++) {
+                if (folders.get(i).getTitle().equals(defaultFolder)) {
+                    chooseFolderSpinner.setSelection(i);
+                    break;
+                }
+            }
+        }
+
+        buttonSaveChanges.setOnClickListener(v ->{
+            String folder_id = ((Folder) chooseFolderSpinner.getSelectedItem()).getId();
+            if (folder_id.equals("0")) {
+                Log.d("NewPostActivity", "Default folder (0) selected");
+                Toast.makeText(this, "Select a folder to save post!", Toast.LENGTH_SHORT).show();
+                return;
+            } else {
+                Log.d("NewPostActivity", "Folder id: " + folder_id);
+                String title = ((EditText) findViewById(R.id.editTextPostTitle)).getText().toString();
+                String url = ((EditText) findViewById(R.id.editTextPostLink)).getText().toString();
+                String description = ((EditText) findViewById(R.id.editTextPostDescription)).getText().toString();
+
+
+                CreatePostRequest request = new CreatePostRequest(
+                        title,
+                        description,
+                        url,
+                        folder_id
+                );
+                MyApiService apiService = RetrofitClient.getRetrofitInstance().create(MyApiService.class);
+                Call<ResponseBody> call = apiService.createPost(User.getUser().getTokenHeaderString(), request);
+                call.enqueue(new Callback<ResponseBody>() {
+                    @Override
+                    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                        if (response.isSuccessful()) {
+                            Toast.makeText(NewPostActivity.this, "Created post!", Toast.LENGTH_SHORT).show();
+                            finish();
+                            Intent intent = new Intent(NewPostActivity.this, DashboardActivity.class);
+                            startActivity(intent);
+                        } else {
+                            Toast.makeText(NewPostActivity.this, "Failed to create post", Toast.LENGTH_SHORT).show();
+                            Log.d("NewPostActivity", "Failed to create post: " + response.code() + " " + response.message());
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<ResponseBody> call, Throwable t) {
+                        Toast.makeText(NewPostActivity.this, "Faied to create post", Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+        });
     }
 }

--- a/app/src/main/java/com/example/poste/activities/NewPostActivity.java
+++ b/app/src/main/java/com/example/poste/activities/NewPostActivity.java
@@ -1,0 +1,61 @@
+package com.example.poste.activities;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Spinner;
+import android.widget.Toast;
+import android.util.Log;
+
+
+import com.example.poste.R;
+import com.example.poste.callbacks.UpdateCallback;
+import com.example.poste.models.Folder;
+import com.example.poste.models.User;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+public class NewPostActivity extends AppCompatActivity {
+
+    private String title;
+
+    private String link;
+
+    private String description;
+
+    private String tags;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_new_post);
+        if (User.getUser().getToken() == null || User.getUser().getToken().isEmpty()) {
+            // user needs to login
+            Log.d("NewPostActivity", "User needs to login");
+            Intent loginIntent = new Intent(this, LoginActivity.class);
+            loginIntent.putExtra("return", true);
+            startActivity(loginIntent);
+        } else {
+            Log.d("NewPostActivity", "User is logged in");
+            Log.d("NewPostActivity", "User token: " + User.getUser().getToken());
+        }
+        handleSharedContent(getIntent());
+
+    }
+
+
+    private void handleSharedContent(Intent intent) {
+        String sharedText = intent.getStringExtra(Intent.EXTRA_TEXT);
+        if (sharedText != null) {
+            EditText linkEditText = findViewById(R.id.editTextPostLink);
+            linkEditText.setText(sharedText);
+        }
+    }
+}

--- a/app/src/main/java/com/example/poste/http/CreatePost.java
+++ b/app/src/main/java/com/example/poste/http/CreatePost.java
@@ -6,12 +6,12 @@ public class CreatePost {
     private String description;
 
     private String url;
-    private String folder;
+    private String folder_id;
 
-    public CreatePost(String title, String description, String url, String folder) {
+    public CreatePost(String title, String description, String url, String folder_id) {
         this.title = title;
         this.description = description;
         this.url = url;
-        this.folder = folder;
+        this.folder_id = folder_id;
     }
 }

--- a/app/src/main/java/com/example/poste/http/CreatePostRequest.java
+++ b/app/src/main/java/com/example/poste/http/CreatePostRequest.java
@@ -1,15 +1,15 @@
 package com.example.poste.http;
 
-public class PostRequest {
+public class CreatePostRequest {
     private String title;
     private String description;
     private String url;
-    private String folder;
+    private String folder_id;
 
-    public PostRequest(String title, String description, String url, String folder) {
+    public CreatePostRequest(String title, String description, String url, String folder_id) {
         this.title = title;
         this.description = description;
         this.url = url;
-        this.folder = folder;
+        this.folder_id = folder_id;
     }
 }

--- a/app/src/main/java/com/example/poste/http/MyApiService.java
+++ b/app/src/main/java/com/example/poste/http/MyApiService.java
@@ -60,7 +60,7 @@ public interface MyApiService {
     @POST("posts/")
     Call<ResponseBody> createPost(
             @Header("Authorization") String authToken,
-            @Body PostRequest postRequest
+            @Body CreatePostRequest createPostRequest
     );
 
     /**

--- a/app/src/main/java/com/example/poste/models/Folder.java
+++ b/app/src/main/java/com/example/poste/models/Folder.java
@@ -62,6 +62,11 @@ public class Folder {
         return title;
     }
 
+    @Override
+    public String toString() {
+        return title;
+    }
+
     public Post getPostFromFolder(String postId){
         for (Post post:
                 posts) {

--- a/app/src/main/java/com/example/poste/models/User.java
+++ b/app/src/main/java/com/example/poste/models/User.java
@@ -1,16 +1,13 @@
 package com.example.poste.models;
 
 import com.example.poste.callbacks.UpdateCallback;
-import com.example.poste.http.CreatePost;
 import com.example.poste.http.MyApiService;
 import com.example.poste.http.RetrofitClient;
 import com.example.poste.utils.DebugUtils;
 import com.example.poste.callbacks.PostDeletionCallback;
 import com.example.poste.utils.utils;
 
-import android.content.Context;
 import android.util.Log;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 
@@ -225,16 +222,16 @@ public class User {
     public void updateFoldersAndPosts(UpdateCallback callback) {
         MyApiService apiService = RetrofitClient.getRetrofitInstance().create(MyApiService.class);
         Call<ResponseBody> call = apiService.getData(getTokenHeaderString());
+        List<Folder> backup = new ArrayList<>(user.getFolders());
+        List<Folder> newFolders = new ArrayList<>();
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(@NonNull Call<ResponseBody> call, @NonNull Response<ResponseBody> response) {
                 if(response.isSuccessful()) {
-                    List<Folder> backup = user.folders;
-                    // convert response to json obj
                     try {
                         String jsonResponse = response.body().string();
                         Log.d("Response", jsonResponse);
-                        user.folders.clear();
+                        // user.folders.clear();
                         JSONArray jsonArray = new JSONArray(jsonResponse);
                         for (int i = 0; i < jsonArray.length(); i++) {
                             JSONObject folder = jsonArray.getJSONObject(i);
@@ -263,8 +260,10 @@ public class User {
                                     .setPosts(posts)
                                     .setId(folderId)
                                     .build();
-                            user.addFolder(newFolder);
+                            newFolders.add(newFolder);
                         }
+                        user.folders.clear();
+                        user.folders.addAll(newFolders);
                         Log.d(
                                 "UserDebug",
                                 "Retrieved user data from API from User.updateFoldersAndPosts()"
@@ -290,6 +289,8 @@ public class User {
                         "UserDebug",
                         "Error retrieving user data from API in User.updateFoldersAndPosts(), " +
                                 "no response received: ", t);
+                user.folders.clear();
+                user.folders.addAll(backup);
                 callback.onError("Unable to retrieve folders and posts, please try " +
                         "again");
             }
@@ -387,57 +388,5 @@ public class User {
                 }
             }
         }
-    }
-
-    /**
-     * Adds a new post the given folder
-     *
-     * @param folder folder to add the new post to
-     */
-    public void createNewPost(Folder folder, Context context, String title, String description, String url) {
-        MyApiService apiService = RetrofitClient.getRetrofitInstance().create(MyApiService.class);
-        Call<ResponseBody> call = apiService.createPost(getTokenHeaderString() ,new CreatePost(title, description, url, folder.getTitle()));
-        call.enqueue(new Callback<ResponseBody>() {
-            @Override
-            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-                if (response.isSuccessful()) {
-                    Toast.makeText(context,"Post Created", Toast.LENGTH_LONG).show();
-                }
-                else {
-                    Toast.makeText(context,"Post Creation Failed", Toast.LENGTH_LONG).show();
-                    Log.d("Post Creation Failed","Create New Post call returned a response that was not successful");
-                }
-            }
-            @Override
-            public void onFailure(Call<ResponseBody> call, Throwable t) {
-                Toast.makeText(context, "Server Not Responding", Toast.LENGTH_LONG).show();
-            }
-        });
-    }
-
-    /**
-     * Deletes a given post from a given folder in the data model and backend
-     *
-     * @param post the post you want to delete
-     */
-    public void deletePost(Context context, Post post, Folder folder) {
-        MyApiService apiService = RetrofitClient.getRetrofitInstance().create(MyApiService.class);
-        Call<ResponseBody> call = apiService.deletePost(getTokenHeaderString() , post.getId());
-        call.enqueue(new Callback<ResponseBody>() {
-            @Override
-            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-                if (response.isSuccessful()) {
-                    Toast.makeText(context,"Post Deleted", Toast.LENGTH_LONG).show();
-                }
-                else {
-                    Toast.makeText(context,"Failed to delete post.", Toast.LENGTH_LONG).show();
-                    Log.d("Delete Post Failed","Delete Post call returned a response that was not successful");
-                }
-            }
-            @Override
-            public void onFailure(Call<ResponseBody> call, Throwable t) {
-                Toast.makeText(context, "Server Not Responding", Toast.LENGTH_LONG).show();
-            }
-        });
     }
 }

--- a/app/src/main/java/com/example/poste/models/User.java
+++ b/app/src/main/java/com/example/poste/models/User.java
@@ -389,4 +389,8 @@ public class User {
             }
         }
     }
+
+    public boolean isLoggedIn() {
+        return (token != null && !token.isEmpty());
+    }
 }

--- a/app/src/main/java/com/example/poste/utils/ValidationUtils.java
+++ b/app/src/main/java/com/example/poste/utils/ValidationUtils.java
@@ -7,6 +7,14 @@ import org.apache.commons.validator.routines.EmailValidator;
 
 public class ValidationUtils {
 
+    /**
+     * Validate names are valid
+     * Ensures first and last name are not empty and are at most 32 characters
+     * @param context the activity within which this is called
+     * @param firstName String variable containing the first name
+     * @param lastName String variable containing the last name
+     * @return boolean. True if names are valid, false otherwise
+     */
     public static boolean validateNames(Context context, String firstName, String lastName) {
         if (firstName.isEmpty()) {
             Toast.makeText(context, "Please enter your first name!", Toast.LENGTH_SHORT).show();
@@ -24,6 +32,12 @@ public class ValidationUtils {
         return true;
     }
 
+    /**
+     * Validate email is valid
+     * @param context the activity within which this is called
+     * @param email String variable containing the email
+     * @return boolean. True if email is valid, false otherwise
+     */
     public static boolean validateEmail(Context context, String email) {
         if (EmailValidator.getInstance().isValid(email)){
             return true;
@@ -33,6 +47,13 @@ public class ValidationUtils {
         }
     }
 
+    /**
+     * Validate password matches and is valid
+     * @param context the activity within which this is called
+     * @param password String variable containing the password
+     * @param confirmPassword String variable containing the password confirmation
+     * @return boolean. True if password is valid, false otherwise
+     */
     public static boolean validatePassword(Context context, String password, String confirmPassword) {
         if (!password.equals(confirmPassword)) {
             Toast.makeText(context, "Passwords do not match!", Toast.LENGTH_SHORT).show();

--- a/app/src/main/res/layout/activity_new_post.xml
+++ b/app/src/main/res/layout/activity_new_post.xml
@@ -160,9 +160,8 @@
         android:id="@+id/chooseFolderSpinner"
         android:layout_width="249dp"
         android:layout_height="34dp"
-        android:layout_marginStart="4dp"
-        app:layout_constraintStart_toEndOf="@+id/imageViewEditPostIcon"
-        tools:layout_editor_absoluteY="201dp" />
+        app:layout_constraintBottom_toBottomOf="@+id/imageViewEditPostIcon"
+        app:layout_constraintStart_toStartOf="@+id/textViewEditPostTitleLabel" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_new_post.xml
+++ b/app/src/main/res/layout/activity_new_post.xml
@@ -160,6 +160,7 @@
         android:id="@+id/chooseFolderSpinner"
         android:layout_width="249dp"
         android:layout_height="34dp"
+        android:layout_marginStart="4dp"
         app:layout_constraintBottom_toBottomOf="@+id/imageViewEditPostIcon"
         app:layout_constraintStart_toStartOf="@+id/textViewEditPostTitleLabel" />
 

--- a/app/src/main/res/layout/activity_new_post.xml
+++ b/app/src/main/res/layout/activity_new_post.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/imageViewLogoP"
+        android:contentDescription="@string/poste_logo_description"
+        android:layout_width="100dp"
+        android:layout_height="135dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/newlogo_p" />
+
+    <ImageView
+        android:id="@+id/imageViewEditPostIcon"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_marginStart="42dp"
+        android:layout_marginTop="135dp"
+        android:contentDescription="@string/edit_post_icon"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/edit_post_icon" />
+
+    <TextView
+        android:id="@+id/textViewEditPostTitleLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="New Post"
+        android:textSize="35sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toEndOf="@+id/imageViewEditPostIcon"
+        app:layout_constraintTop_toTopOf="@+id/imageViewEditPostIcon" />
+
+    <TextView
+        android:id="@+id/textViewEditPostUrl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="19dp"
+        android:text="Link to post:"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/imageViewEditPostIcon"
+        app:layout_constraintTop_toBottomOf="@+id/imageViewEditPostIcon" />
+
+    <EditText
+        android:id="@+id/editTextPostLink"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:inputType="text"
+        android:paddingStart="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/imageViewEditPostIcon" />
+
+    <TextView
+        android:id="@+id/textViewPostTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:text="Title"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/imageViewEditPostIcon"
+        app:layout_constraintTop_toBottomOf="@+id/editTextPostLink" />
+
+    <EditText
+        android:id="@+id/editTextPostTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:inputType="text"
+        android:paddingStart="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textViewPostTitle"
+        android:layout_marginTop="12dp" />
+
+
+    <EditText
+        android:id="@+id/editTextPostTags"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:inputType="text"
+        android:paddingStart="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/textViewPostTag" />
+
+    <TextView
+        android:id="@+id/textViewPostTag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Tags"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/imageViewEditPostIcon"
+        app:layout_constraintTop_toBottomOf="@+id/editTextPostDescription" />
+
+    <EditText
+        android:id="@+id/editTextPostDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="34dp"
+        android:inputType="text"
+        android:paddingStart="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/textViewPostDescription" />
+
+    <TextView
+        android:id="@+id/textViewPostDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:text="Description"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="@+id/imageViewEditPostIcon"
+        app:layout_constraintTop_toBottomOf="@+id/editTextPostTitle" />
+
+    <Button
+        android:id="@+id/buttonSaveChanges"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="23dp"
+        android:text="Save Changes"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editTextPostTags" />
+
+    <Button
+        android:id="@+id/buttonCancelChanges"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Cancel Changes"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/buttonSaveChanges" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="42dp" />
+
+    <Spinner
+        android:id="@+id/chooseFolderSpinner"
+        android:layout_width="249dp"
+        android:layout_height="34dp"
+        android:layout_marginStart="4dp"
+        app:layout_constraintStart_toEndOf="@+id/imageViewEditPostIcon"
+        tools:layout_editor_absoluteY="201dp" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
 Add content sharing to Poste from outside app

This implements the 'share to Poste' functionality we have been discussing, by allowing a user to select
'share' from another application and share the data to Poste.

Normally, the application opens from IntroActivity, which allows user to choose to Login or Register.
This will change when a user attempts to share to Poste.

Alternate control flow:

1) User clicks 'Share' on some content and selects to share to Poste
2) Application opens NewPostActivity
3) Application checks if user is logged in.
4a) If user is logged in, proceed with post creation, returning to dashboard when done
4b) If user is not logged in, redirect to login page; when logged in, return to NewPostActivity and
proceed with post creation

New Files:
- `NewPostActivity.java`: Represents the activity to create a new post (rather than editing) -- I wanted
to work on a fresh activity rather than modifying EditPostActivity and having to touch too much of the
code in one task. Functionally very similar to EditPostActivity, but there is also a spinner (dropdown
menu) that allows a user to select the folder to create the post in. TODO: We need to determine what
happens if a User attempts to creat a Post, but has no Folders. Options: Create a default 'Home' folder,
give an error, redirect to FolderCreation, etc.
- `activity_new_post.xml`: Layout for the above activity

Changes:
- `AndroidManifest.xml`: Added intent-filter to allow sharing content to NewPostActivity
- `DashboardActivity.java`: Implemented Create Post functionality. Now, when user elects to create a post from
this page, it starts NewPostActivity, but does not finish -- this way, when post creation is finished,
user is returned here
- `LoginActivity.java`: Added checks for 'getBooleanExtra("return")'. This extra information should be passed
to `LoginActivity` when we want `LoginActivity` to simply `finish()` and return to the previous
activity when done, rather than redirecting user to the Dashboard. This is useful when a user tries to
share content to Poste, but they are not logged in -- first, it will ask them to login, but then return
them to NewPostActivity (which called Login) rather than to the Dashboard. If this extra isn't passed
to LoginActivity, they will simply be forwarded to dashboard
- `CreatePost.java`: Modified API request class to match sent data format to that expected by backend
- `Folder.java`: Implemented `toString()`, which is used to display Folder title in NewPostActivity spinner / dropdown
- `User.java`: Removed some duplicate code and unused import, and cleans up updateFoldersAndPosts
- `ValidationUtils.java`: Added some documentation