### PR TITLE
Add some conversions / string values to enums

### DIFF
--- a/app/src/main/java/com/example/poste/api/poste/models/FolderAccess.java
+++ b/app/src/main/java/com/example/poste/api/poste/models/FolderAccess.java
@@ -1,18 +1,22 @@
 package com.example.poste.api.poste.models;
 
 public enum FolderAccess {
-    NONE(0),
-    VIEWER(1),
-    EDITOR(2),
-    FULL_ACCESS(3);
+    NONE(0, "none"),
+    VIEWER(1, "viewer"),
+    EDITOR(2, "editor"),
+    FULL_ACCESS(3, "full_access");
 
     private final int value;
+    private final String stringValue;
 
-    FolderAccess(final int newValue) {
+    FolderAccess(final int newValue, final String stringValue) {
         value = newValue;
+        this.stringValue = stringValue;
     }
 
     public int getValue() { return value; }
+
+    public String getStringValue() { return stringValue; }
 
     public static FolderAccess valueOf(int value) {
         switch (value) {

--- a/app/src/main/java/com/example/poste/http/UpdateFolderPermissionsRequest.java
+++ b/app/src/main/java/com/example/poste/http/UpdateFolderPermissionsRequest.java
@@ -7,9 +7,9 @@ public class UpdateFolderPermissionsRequest {
         this.folderId = folderId;
         // this is necessary else the user is sometimes not found
         this.email = email.toLowerCase();
-        this.permission = permission;
+        this.permission = permission.getStringValue();
     }
     private String folderId;
     private String email;
-    private FolderAccess permission;
+    private String permission;
 }


### PR DESCRIPTION
Kim -- This is kinda messy and probably defeats the purposes of using an enum in the first place. I'm just so used to using constants rather than enums... and this is just how I got this working with the backend the way it is. Originally I wanted to ensure we sent a string so we didnt have to change the backend, but the backend ended up requiring changes anyway so... idk. Oh well.

This is tested working with the backend changes I made a PR for back to your branch.

Feel free to take / leave / modify as you see fit. Not trying to step on toes, just trying to assist, so if you want to ignore these PR please feel free.