### PR TITLE
Abstract API endpoint to build variable

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,11 +16,11 @@ jobs:
     - name: set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew assembleDevelopment

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ local.properties
 apikey.properties
 apikey.properties
 .idea/
-/app/src/main/res/raw/poste.crt
+*.crt
+*.key
+*.pem

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,21 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        development {
+            debuggable true
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField "String", "API_ENDPOINT", '"https://postebackend.duckdns.org/api/"'
+            signingConfig signingConfigs.debug
+        }
+        local {
+            debuggable true
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField "String", "API_ENDPOINT", '"https://10.0.2.2/api/"'
+            signingConfig signingConfigs.debug
+        }
+
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/src/main/java/com/example/poste/http/RetrofitClient.java
+++ b/app/src/main/java/com/example/poste/http/RetrofitClient.java
@@ -1,5 +1,6 @@
 package com.example.poste.http;
 
+import com.example.poste.BuildConfig;
 import com.example.poste.R;
 import com.example.poste.models.PosteApp;
 import com.example.poste.utils.NullHostNameVerifier;
@@ -29,7 +30,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 public class RetrofitClient {
 
-    private static final String BASE_URL = "https://10.0.2.2/api/";
+    private static final String BASE_URL = BuildConfig.API_ENDPOINT;
     private static Retrofit retrofit;
     private static OkHttpClient.Builder client = null;
 

--- a/app/src/main/java/com/example/poste/http/RetrofitClient.java
+++ b/app/src/main/java/com/example/poste/http/RetrofitClient.java
@@ -40,8 +40,7 @@ public class RetrofitClient {
             logging.setLevel(HttpLoggingInterceptor.Level.BODY);
             client = new OkHttpClient.Builder()
                     .readTimeout(5, TimeUnit.SECONDS)
-                    .addInterceptor(logging)
-                    .hostnameVerifier(new NullHostNameVerifier());
+                    .addInterceptor(logging);
             // adds the SSL to the httpClient so it can use https with TLS encoding
             // to use need to change URl to an https one
             initSSL();


### PR DESCRIPTION
This commit abstracts the API endpoint to a build variable, which allows us to dynamically switch between using a local server or the development server.

The development server is located at: https://postebackend.duckdns.org

This adds a new build config; there are now four:
- `local`: The API endpoint will be set to https://10.0.2.2/api/ (uses a local backend)
- `development`: The API endpoint will be set to  https://postebackend.duckdns.org/api/ (Amazon EC2 development server)
- release: Previously existing. Did not change.
- debug: Previously existing. Did not change

To use a different build variant, do the following:

1) Open Android studio
2) In Menu bar, click Build > Select Build Variant
3) In the Build Variant tool window, change between `development` or `local` as desired.

When changing Build Variant, you may need to rebuild the project manually:
1) In the Menu bar, click Build > Clean Project
2) In the Menu bar, click Build > Rebuild Project
3) Run application

Occasionally, after changing build variant, running the application may throw an error:
`Couldn't delete Poste\app\build\intermediates\compile_and_runtime_not_namespaced_r_class_jar\development\R.jar`

Clicking Run again should remove the error as it rebuilds; this may also be resolved by changing the Run configuration.

NOTE: `Poste.crt` must be present in `res/raw` since this now uses HTTPS; see the Backend repo for crt generation instructions.