### PR TITLE
Remove nullhostverifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ local.properties
 apikey.properties
 apikey.properties
 .idea/
-/app/src/main/res/raw/poste.crt
+*.crt
+*.key
+*.pem

--- a/app/src/main/java/com/example/poste/http/RetrofitClient.java
+++ b/app/src/main/java/com/example/poste/http/RetrofitClient.java
@@ -40,8 +40,7 @@ public class RetrofitClient {
             logging.setLevel(HttpLoggingInterceptor.Level.BODY);
             client = new OkHttpClient.Builder()
                     .readTimeout(5, TimeUnit.SECONDS)
-                    .addInterceptor(logging)
-                    .hostnameVerifier(new NullHostNameVerifier());
+                    .addInterceptor(logging);
             // adds the SSL to the httpClient so it can use https with TLS encoding
             // to use need to change URl to an https one
             initSSL();


### PR DESCRIPTION
Having fixed the cert issue, I have removed the null host verifier.

I have tested this against our development server using branch `us270t300`. I have verified the certs are all matching. Go to https://drive.google.com/drive/u/1/folders/1j98_tcubzJN6FDu242OCpX6qWqD4A0L1 and follow the READMEs for the certs and more instructions.