### PR TITLE
Extract crt into GitHub variable

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,7 +24,7 @@ jobs:
       run: chmod +x gradlew
     - name: Replace Certificate
       run: |
-        echo "${{ secrets.REAL_CERTIFICATE }}" | base64 -d > .app/src/main/res/raw/poste.crt
+        echo "${{ secrets.REAL_CERTIFICATE }}" | base64 -d > ./app/src/main/res/raw/poste.crt
 
     - name: Build with Gradle
       run: ./gradlew assembleDevelopment

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,5 +22,9 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Replace Certificate
+      run: |
+        echo "${{ secrets.REAL_CERTIFICATE }}" | base64 -d > .app/src/main/res/raw/poste.crt
+
     - name: Build with Gradle
       run: ./gradlew assembleDevelopment


### PR DESCRIPTION
Rather than using a placeholder poste.txt which we need to manually delete (without tracking changes to the repository), GitHub workflow will now use an environment variable to fill in `poste.crt` in the `app/src/main/res/raw` directory.

This means we no longer need to keep the placeholder `poste.txt` around and don't need to worry about tracking its deletion into the repository. After merging, developers should remove `poste.txt` from their local versions